### PR TITLE
Removing the stats global state

### DIFF
--- a/src/components/EventCard/EventCard.js
+++ b/src/components/EventCard/EventCard.js
@@ -43,7 +43,7 @@ const EventCard = (props) => {
             >
               {statusText}
             </Paragraph>
-            <Stats year={year} isSimplified />
+            <Stats event={event} isSimplified />
           </div>
         </Card>
       </a>

--- a/src/components/ParticipationForm/ParticipationForm.js
+++ b/src/components/ParticipationForm/ParticipationForm.js
@@ -48,7 +48,7 @@ const ParticipationForm = (props) => {
       );
       dispatchWithLoading(ActionTypes.REGISTER_PARTICIPATION, notes, year).then(
         () => {
-          dispatchWithLoading(ActionTypes.GET_STATS, year);
+          dispatchWithLoading(ActionTypes.GET_EVENTS);
         }
       );
     }
@@ -56,7 +56,7 @@ const ParticipationForm = (props) => {
 
   const handleRemoveParticipationClick = () => {
     dispatchWithLoading(ActionTypes.REMOVE_PARTICIPATION, year).then(() => {
-      dispatchWithLoading(ActionTypes.GET_STATS, year);
+      dispatchWithLoading(ActionTypes.GET_EVENTS);
     });
   };
 

--- a/src/components/Stats/Stats.js
+++ b/src/components/Stats/Stats.js
@@ -2,22 +2,20 @@ import {
   DescriptionList,
   DescriptionListItem,
 } from "@/components/DescriptionList";
-import { simplifiedStatData, statData } from "@/utils/stats";
+import { getStatsFromEvent, simplifiedStatData, statData } from "@/utils/stats";
 import t from "prop-types";
 import { useEffect, useState } from "react";
-import { useGlobal } from "reactn";
 
 const Stats = (props) => {
-  const { isSimplified, year } = props;
-  const [stats] = useGlobal("stats");
+  const { isSimplified, event } = props;
   const [yearlyStats, setYearlyStats] = useState(null);
   const selectedStatData = isSimplified ? simplifiedStatData : statData;
 
   useEffect(() => {
-    if (stats && year) {
-      setYearlyStats(stats[year]);
+    if (event) {
+      setYearlyStats(getStatsFromEvent(event));
     }
-  }, [stats, year]);
+  }, [event]);
 
   const renderStats = () => {
     if (!yearlyStats) return null;
@@ -59,7 +57,7 @@ const Stats = (props) => {
 
 Stats.propTypes = {
   isSimplified: t.bool,
-  year: t.string,
+  event: t.object,
 };
 
 export default Stats;

--- a/src/pages/events/[year].js
+++ b/src/pages/events/[year].js
@@ -47,10 +47,6 @@ const EventPage = (props) => {
   const [isLoading, setLoading] = useState(null);
 
   useEffect(() => {
-    if (year) dispatchWithLoading(ActionTypes.GET_STATS, year);
-  }, [year]);
-
-  useEffect(() => {
     if (user && year) {
       dispatchWithLoading(ActionTypes.GET_GIFTS, year);
       dispatchWithLoading(ActionTypes.GET_PARTICIPATION_STATUS);
@@ -79,15 +75,16 @@ const EventPage = (props) => {
     if (isLoading !== false) {
       setLoading(
         loading[ActionTypes.GET_EVENTS] ||
-          loading[ActionTypes.GET_STATS] ||
           loading[ActionTypes.GET_PARTICIPATION_STATUS] ||
-          loading[ActionTypes.GET_USER]
+          loading[ActionTypes.GET_USER] ||
+          loading[ActionTypes.GET_GIFTS]
       );
     }
   }, [
-    loading[ActionTypes.GET_STATS],
+    loading[ActionTypes.GET_EVENTS],
     loading[ActionTypes.GET_PARTICIPATION_STATUS],
     loading[ActionTypes.GET_USER],
+    loading[ActionTypes.GET_GIFTS],
   ]);
 
   const handleDonateClick = () => {
@@ -97,7 +94,7 @@ const EventPage = (props) => {
   const renderStats = () => (
     <>
       <Title>Statistics</Title>
-      <Stats year={year} />
+      <Stats event={event} />
     </>
   );
 

--- a/src/store/initialState.js
+++ b/src/store/initialState.js
@@ -13,6 +13,5 @@ export default {
   loading: {},
   participations: null,
   stage: null,
-  stats: null,
   user: null,
 };

--- a/src/store/reducers/firebaseReducers.js
+++ b/src/store/reducers/firebaseReducers.js
@@ -5,11 +5,4 @@ export default {
     const stage = await global.firebase.getStage();
     return { stage };
   },
-
-  [ActionTypes.GET_STATS]: async (global, dispatch, year) => {
-    const stats = await global.firebase.getStats(year);
-    return {
-      stats: { ...global.stats, [stats.year]: stats },
-    };
-  },
 };

--- a/src/store/reducers/giftReducers.js
+++ b/src/store/reducers/giftReducers.js
@@ -9,7 +9,7 @@ export default {
   [ActionTypes.SEND_GIFT]: async (global, dispatch, giftId, isSent, year) => {
     await global.firebase.sendGift(global.user.uid, giftId, isSent, year);
     await dispatch[ActionTypes.GET_GIFTS](year);
-    await dispatch[ActionTypes.GET_STATS](year);
+    await dispatch[ActionTypes.GET_EVENTS]();
   },
 
   [ActionTypes.RECEIVE_GIFT]: async (
@@ -26,7 +26,7 @@ export default {
       year
     );
     await dispatch[ActionTypes.GET_GIFTS](year);
-    await dispatch[ActionTypes.GET_STATS](year);
+    await dispatch[ActionTypes.GET_EVENTS]();
   },
 
   [ActionTypes.REPORT_GIFT]: async (

--- a/src/utils/stats.js
+++ b/src/utils/stats.js
@@ -39,3 +39,17 @@ export const simplifiedStatData = {
     icon: <ion-icon name="people" />,
   },
 };
+
+export const getStatsFromEvent = (event) => {
+  if (!event) return null;
+
+  return {
+    participants: event.participants,
+    giftsSent: event.giftsSent,
+    donationsSent: event.donationsSent,
+    signupStart: event.signupStart,
+    eventStart: event.eventStart,
+    eventEnd: event.eventEnd,
+    year: event.year,
+  };
+};

--- a/src/utils/types/ActionTypes.js
+++ b/src/utils/types/ActionTypes.js
@@ -26,7 +26,6 @@ export default {
 
   // Firebase
   GET_STAGE: "updateStage",
-  GET_STATS: "updateStats",
 
   // Other reducers
   SET_ERROR: "setError",


### PR DESCRIPTION
This PR fixes #55 and #58.

Now using stats from event object.
The loading indicator of event page is now showing when loading.

